### PR TITLE
:bug: Display 'processing' on emscripten preInit

### DIFF
--- a/Kong Preloader/index.html
+++ b/Kong Preloader/index.html
@@ -131,7 +131,7 @@
   <script src="%UNITY_WEBGL_LOADER_URL%"></script>
   <script>
     function UnityProgress(gameInstance, progress) {
-      var container = document.getElementById('gameContainer');
+      var container = document.getElementById("gameContainer");
       if (container) document.body.style.background = container.style.background;
 
       if (!gameInstance.Module) {
@@ -141,8 +141,7 @@
         document.getElementById("icon").style.display = "none";
         document.getElementById("loadingInfo").style.display = "none";
         document.getElementById("box").style.display = "none";
-        return;
-      } else if (progress == 1) {
+      } else if (progress === 1 || progress === "preinit") {
         document.getElementById("loadingInfo").innerHTML = "PROCESSING...";
         document.getElementById("spinner").style.display = "inherit";
         document.getElementById("bgBar").style.display = "none";
@@ -158,7 +157,8 @@
     var gameInstance = UnityLoader.instantiate("gameContainer", "%UNITY_WEBGL_BUILD_URL%", {
       onProgress: UnityProgress,
       Module: {
-        onRuntimeInitialized: function() { UnityProgress(gameInstance, "complete") }
+        onRuntimeInitialized: function() { UnityProgress(gameInstance, "complete"); },
+        preInit: [function() { UnityProgress(gameInstance, "preinit"); }]
       }
     });
   </script>


### PR DESCRIPTION
This works around an issue with newer versions of Unity where the 100% progress event comes after `onRuntimeInitialized`